### PR TITLE
Fix/1 : fix issue #6 #21

### DIFF
--- a/src/components/elements/videoInfo.tsx
+++ b/src/components/elements/videoInfo.tsx
@@ -2,22 +2,22 @@ import parseViews from '../../lib/utils/parseViews'
 import { IVideo } from '../../types'
 
 interface IProps {
-  data: IVideo
+  data?: IVideo
 }
 
 export default function VideoInfo({ data }: IProps) {
   return (
     <div className="space-y-1">
-      <div className="text-lg">{data.title}</div>
+      <div className="text-lg">{data?.title}</div>
       <div className="flex gap-4">
-        {data.views && (
+        {data?.views && (
           <div className="text-base text-blackberry-lightest leading-8">조회수 {parseViews(data?.views)}회</div>
         )}
-        <div className="text-base text-blackberry-lightest leading-8">{data.uploadedAt}</div>
+        <div className="text-base text-blackberry-lightest leading-8">{data?.uploadedAt}</div>
       </div>
       <div className="flex gap-2">
-        <img src={data.channelAvatar} alt={'channel'} className="w-8 h-8 rounded-full" />
-        <div className="text-base leading-8">{data.channelTitle}</div>
+        <img src={data?.channelAvatar} alt={'channel'} className="w-8 h-8 rounded-full" />
+        <div className="text-base leading-8">{data?.channelTitle}</div>
       </div>
     </div>
   )

--- a/src/components/play/index.tsx
+++ b/src/components/play/index.tsx
@@ -21,6 +21,7 @@ export default function Play({ videoList }: IProps) {
   const playerRef = useRef<ReactPlayer>(null)
   const dispatch = useDispatch()
   const navigate = useNavigate()
+
   const onVideoEnd = useCallback(() => {
     setCurrentVideoIndex(prev => {
       if (prev + 1 < videoList.length) {

--- a/src/routes/Play.tsx
+++ b/src/routes/Play.tsx
@@ -1,20 +1,23 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
 import { useNavigate } from 'react-router-dom'
+import LoadingElement from '../components/elements/loading'
 import PlayIndex from '../components/play'
 import { RootModuleType } from '../modules/moduleTypes'
 
 function Play() {
   const videoList = useSelector(({ video }: RootModuleType) => video.items)
+  const [loading, setLoading] = useState(true)
   const navigate = useNavigate()
 
   useEffect(() => {
     if (videoList.length === 0) {
       navigate('/')
     }
+    setLoading(false)
   }, [navigate, videoList])
 
-  return <PlayIndex videoList={videoList} />
+  return <>{loading ? <LoadingElement /> : <PlayIndex videoList={videoList} />}</>
 }
 
 export default Play


### PR DESCRIPTION
#6 useEffect로 videoList가 있는지 검사하기 전까지는 loadingElement를 띄우도록 하여 해결
#21  동영상이 변경되었을때, 아직 비디오가 ready되지 않았는데 seekTo를 했을 경우 발생함. 따라서 비디오가 변경되었을 경우 videoReady 상태를 false로 두고, videoReady가 true가 되기 전까지는 seekTo 하지 않도록 함.